### PR TITLE
Some improvements

### DIFF
--- a/src/bevyTreeDataProvider.ts
+++ b/src/bevyTreeDataProvider.ts
@@ -122,5 +122,42 @@ export class BevyTreeDataProvider implements TreeDataProvider<BevyTreeData> {
 }
 
 function shortenName(name: string): string {
-    return name.split("::").at(-1) ?? name;
+    const collapseTypeName = (string: string): string => {
+        const segments = string.split("::");
+        const last = segments.pop()!;
+        const secondLast = segments.pop();
+        if (secondLast && /^[A-Z]/.test(secondLast)) {
+            return `${secondLast}::${last}`;
+        }
+        return last;
+    };
+
+    let result = "";
+    let index = 0;
+
+    while (index < name.length) {
+        const rest = name.slice(index);
+        const specialCharIndex = rest.search(/[ <>()[\],;]/);
+        if (specialCharIndex === -1) {
+            result += collapseTypeName(rest);
+            break;
+        }
+
+        const segment = rest.slice(0, specialCharIndex);
+        result += collapseTypeName(segment);
+
+        const specialChar = rest[specialCharIndex];
+        result += specialChar;
+
+        if (["<", "("].includes(specialChar)) {
+            index += specialCharIndex + 1;
+        } else if ([">", ")"].includes(specialChar) && rest[specialCharIndex + 1] === ":") {
+            result += "::";
+            index += specialCharIndex + 3;
+        } else {
+            index += specialCharIndex + 1;
+        }
+    }
+
+    return result;
 }

--- a/src/bevyTreeDataProvider.ts
+++ b/src/bevyTreeDataProvider.ts
@@ -130,6 +130,7 @@ export class BevyTreeDataProvider implements TreeDataProvider<BevyTreeData> {
     }
 }
 
+// https://github.com/bevyengine/disqualified/blob/cc4940da85aa64070a34da590ff5aab12e7c951d/src/short_name.rs#L50
 function shortenName(name: string): string {
     const collapseTypeName = (string: string): string => {
         const segments = string.split("::");

--- a/src/bevyTreeDataProvider.ts
+++ b/src/bevyTreeDataProvider.ts
@@ -78,7 +78,7 @@ export class BevyTreeDataProvider implements TreeDataProvider<BevyTreeData> {
     private buildEntityTreeItem(entity: Entity): TreeItem {
         const treeItem = new TreeItem(entity.name || entity.id.toString(), TreeItemCollapsibleState.Collapsed);
         if (entity.name !== undefined) {
-            treeItem.description = entity.id.toString();
+            treeItem.tooltip = entity.id.toString();
         }
         treeItem.iconPath = new ThemeIcon('symbol-class');
         treeItem.contextValue = 'entity';
@@ -88,7 +88,7 @@ export class BevyTreeDataProvider implements TreeDataProvider<BevyTreeData> {
     private buildComponentNameTreeItem(component: Component): TreeItem {
         let { name, errorMessage } = component;
         const treeItem = new TreeItem(shortenName(name), TreeItemCollapsibleState.Collapsed);
-        treeItem.description = name;
+        treeItem.tooltip = name;
         treeItem.iconPath = new ThemeIcon(errorMessage === undefined ? 'checklist' : 'error');
         treeItem.contextValue = 'component';
         return treeItem;

--- a/src/bevyTreeDataProvider.ts
+++ b/src/bevyTreeDataProvider.ts
@@ -37,7 +37,9 @@ export class BevyTreeDataProvider implements TreeDataProvider<BevyTreeData> {
             } else if (element instanceof Entity) {
                 return await this.service.listComponents(element.id);
             } else if (element instanceof Component) {
-                return await this.service.buildComponentValueTree(element);
+                if (!isPrimitiveComponent(element)) {
+                    return await this.service.buildComponentValueTree(element);
+                }
             } else if (element instanceof ComponentValue) {
                 return element.children;
             }
@@ -87,9 +89,16 @@ export class BevyTreeDataProvider implements TreeDataProvider<BevyTreeData> {
 
     private buildComponentNameTreeItem(component: Component): TreeItem {
         let { name, errorMessage } = component;
-        const treeItem = new TreeItem(shortenName(name), TreeItemCollapsibleState.Collapsed);
+        const treeItem = new TreeItem(shortenName(name));
         treeItem.tooltip = name;
+
+        let isPrimitive = isPrimitiveComponent(component);
+        if (isPrimitive) {
+            treeItem.description = JSON.stringify(component.value);
+        }
+
         treeItem.iconPath = new ThemeIcon(errorMessage === undefined ? 'checklist' : 'error');
+        treeItem.collapsibleState = isPrimitive ? TreeItemCollapsibleState.None : TreeItemCollapsibleState.Collapsed;
         treeItem.contextValue = 'component';
         return treeItem;
     }
@@ -160,4 +169,12 @@ function shortenName(name: string): string {
     }
 
     return result;
+}
+
+function isPrimitiveComponent(component: Component) {
+    if (component.value instanceof Object) {
+        if (Object.keys(component.value).length == 0) return true;
+        return false;
+    }
+    return true;
 }

--- a/src/bevyViewService.ts
+++ b/src/bevyViewService.ts
@@ -99,7 +99,15 @@ export class BevyTreeService {
             // Sort so that children are on top, then component name in lexicographical order.
             const aIsChildren = a.name === 'bevy_hierarchy::components::children::Children';
             const bIsChildren = b.name === 'bevy_hierarchy::components::children::Children';
-            return aIsChildren ? -1 : bIsChildren ? 1 : a.name.localeCompare(b.name);
+            if (aIsChildren) return -1;
+            else if (bIsChildren) return 1;
+            else {
+                let aHasErrors = a.errorMessage != undefined;
+                let bHasErrors = b.errorMessage != undefined;
+                if (aHasErrors && !bHasErrors) return 1;
+                if (bHasErrors && !aHasErrors) return -1;
+                return a.name.localeCompare(b.name);
+            }
         });
     }
 

--- a/src/bevyViewService.ts
+++ b/src/bevyViewService.ts
@@ -207,6 +207,7 @@ export class BevyTreeService {
 
 
 function inferEntityName(components: string[]): string | null {
+    // https://github.com/jakobhellermann/bevy-inspector-egui/blob/b203ca5c3f688dddbe7245f87bfcd74acd4f5da3/crates/bevy-inspector-egui/src/utils.rs#L57
     let associations: Record<ComponentName, string> = {
         "bevy_window::window::PrimaryWindow": "Primary Window",
         "bevy_core_pipeline::core_3d::camera_3d::Camera3d": "Camera3d",


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/c015bd87-f3f5-4c00-975a-543abfbe8247)


- fix the `shortenName` function for more complex generics
- try to infer a good name from the components, even if no `Name` component exists
- sort unreflectable components to the bottom
- move the entity ID and the full component typename to tooltip instead of description
- When possible, show primitive values directly inline as the description instead of having to open the dropdown.
This is the most subjective one so if you don't like it I can revert that commit. 
![image](https://github.com/user-attachments/assets/9af070fa-d70f-4972-9ed8-d76937cef983)
