### PR TITLE
Support different Bevy versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,20 @@
           "format": "uri",
           "default": "http://127.0.0.1:15702"
         },
+        "bevyInspector.bevyVersion": {
+          "type": "string",
+          "title": "Bevy Version",
+          "description": "Version of Bevy that defines the Bevy Remote Protocol version.",
+          "default": "<= 0.15",
+          "enum": [
+            "<= 0.15",
+            "> 0.15"
+          ],
+          "enumItemLabels": [
+            "Version 0.15 or earlier",
+            "Version later than 0.15"
+          ]
+        },
         "bevyInspector.pollingDelay": {
           "type": "number",
           "title": "Polling delay",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { BevyTreeDataProvider } from './bevyTreeDataProvider';
-import { BevyTreeService, Entity } from './bevyViewService';
+import { BevyTreeService, DEFAULT_BEVY_VERSION, Entity } from './bevyViewService';
 import { JsonRpcBevyRemoteService } from './jsonRpcBrp';
 import { PollingService } from './polling';
 
@@ -9,7 +9,8 @@ const DEFAULT_URL = 'http://127.0.0.1:15702';
 export function activate(context: vscode.ExtensionContext) {
 	const url = vscode.workspace.getConfiguration('bevyInspector').get('url', DEFAULT_URL);
 	const remoteService = new JsonRpcBevyRemoteService(url);
-	const treeDataProvider = new BevyTreeDataProvider(new BevyTreeService(remoteService));
+	const treeService = new BevyTreeService(remoteService);
+	const treeDataProvider = new BevyTreeDataProvider(treeService);
 	vscode.window.createTreeView('bevyInspector', {
 		treeDataProvider,
 		showCollapseAll: true,
@@ -22,6 +23,10 @@ export function activate(context: vscode.ExtensionContext) {
 	vscode.workspace.onDidChangeConfiguration((e) => {
 		if (e.affectsConfiguration('bevyInspector.url')) {
 			remoteService.url = vscode.workspace.getConfiguration('bevyInspector').get('url', DEFAULT_URL);
+		}
+		if (e.affectsConfiguration('bevyInspector.bevyVersion')) {
+			treeService.bevyVersion = vscode.workspace.getConfiguration('bevyInspector').get('bevyVersion', DEFAULT_BEVY_VERSION);
+			treeDataProvider.refresh();
 		}
 		if (e.affectsConfiguration('bevyInspector.pollingDelay')) {
 			polling.restart();


### PR DESCRIPTION
Add a "Bevy version" setting that governs the version of BRP used to communicate to the Bevy application.

In particular, it governs which Name component to query (`bevy_core::name::Name` in Bevy <= `0.15` or `bevy_ecs::name::Name` in Bevy > `0.15`). This is important since currently, BRP sends an error when querying the wrong Name component.

Fixes #2.