### PR TITLE
Add Go to Definition to components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.0.1",
       "dependencies": {
         "axios": "^1.7.9",
+        "fast-levenshtein": "^3.0.0",
         "json-rpc-types": "^0.1.1"
       },
       "devDependencies": {
+        "@types/fast-levenshtein": "^0.0.4",
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
         "@types/vscode": "^1.95.0",
@@ -793,6 +795,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/fast-levenshtein": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fast-levenshtein/-/fast-levenshtein-0.0.4.tgz",
+      "integrity": "sha512-tkDveuitddQCxut1Db8eEFfMahTjOumTJGPHmT9E7KUH+DkVq9WTpVvlfenf3S+uCBeu8j5FP2xik/KfxOEjeA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2342,11 +2351,22 @@
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz",
+      "integrity": "sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fastest-levenshtein": "^1.0.7"
+      }
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -4289,6 +4309,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/optionator/node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ora": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,12 @@
     ],
     "commands": [
       {
+        "command": "bevyInspector.goToDefinition",
+        "title": "Go to Definition",
+        "icon": "$(go-to-file)",
+        "category": "Bevy Inspector"
+      },
+      {
         "command": "bevyInspector.refresh",
         "title": "Refresh",
         "icon": "$(refresh)",
@@ -103,9 +109,16 @@
         {
           "command": "bevyInspector.copyComponentName",
           "when": "view == bevyInspector && viewItem == component"
+        },
+        {
+          "command": "bevyInspector.goToDefinition",
+          "when": "view == bevyInspector && viewItem == component"
         }
       ],
       "commandPalette": [
+        {
+          "command": "bevyInspector.goToDefinition"
+        },
         {
           "command": "bevyInspector.refresh"
         },
@@ -170,9 +183,11 @@
   },
   "dependencies": {
     "axios": "^1.7.9",
+    "fast-levenshtein": "^3.0.0",
     "json-rpc-types": "^0.1.1"
   },
   "devDependencies": {
+    "@types/fast-levenshtein": "^0.0.4",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
     "@types/vscode": "^1.95.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+import levenshtein from 'fast-levenshtein';
 import * as vscode from 'vscode';
 import { BevyTreeDataProvider } from './bevyTreeDataProvider';
 import { BevyTreeService, Component, DEFAULT_BEVY_VERSION, Entity } from './bevyViewService';
@@ -25,6 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
 			await vscode.env.clipboard.writeText(component.name);
 		}
 	});
+	vscode.commands.registerCommand('bevyInspector.goToDefinition', goToDefinition);
 	vscode.workspace.onDidChangeConfiguration((e) => {
 		if (e.affectsConfiguration('bevyInspector.url')) {
 			remoteService.url = vscode.workspace.getConfiguration('bevyInspector').get('url', DEFAULT_URL);
@@ -37,4 +39,38 @@ export function activate(context: vscode.ExtensionContext) {
 			polling.restart();
 		}
 	});
+}
+
+async function goToDefinition(component: Component) {
+	if (!component?.name) {
+		vscode.window.showWarningMessage('No selected component.');
+		return;
+	}
+	const location = await findSymbolLocation(component.name);
+	if (location && location.uri) {
+		const document = await vscode.workspace.openTextDocument(location.uri);
+		const editor = await vscode.window.showTextDocument(document);
+		editor.revealRange(location.range, vscode.TextEditorRevealType.InCenter);
+		editor.selection = new vscode.Selection(location.range.start, location.range.start);
+	} else {
+		await vscode.window.showInformationMessage(`No symbol found in workspace for component "${component.name}".`);
+	}
+}
+
+async function findSymbolLocation(componentName: string): Promise<vscode.Location | null> {
+	const query = (componentName.match(/(?:\w+::)*(\w+)/) || [])[1];
+	if (query) {
+		const symbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>('vscode.executeWorkspaceSymbolProvider', query);
+		if (symbols && symbols.length > 0) {
+			console.debug(`Found symbols for query "${query}": "${symbols.map(symbol => symbol.name)}".`);
+			const firstSymbol = symbols.reduce((previous, current) => {
+				const prevDistance = levenshtein.get(query, previous.name);
+				const currDistance = levenshtein.get(query, current.name);
+				return currDistance < prevDistance ? current : previous;
+			}, symbols[0]);
+			console.debug(`Found symbol for query "${query}": "${JSON.stringify(firstSymbol)}".`);
+			return firstSymbol.location;
+		}
+	}
+	return null;
 }


### PR DESCRIPTION
Adds a menu item to components right click menu.

It allows to navigate to a Rust type that matches the component's name.

This implementation has limitations though:

- It cannot find symbols that are not in the workspace, meaning dependencies such as `bevy_transform::components::transform::Transform` are not found.
- It doesn't take into account the fully classified component name, only the last part. So it can find another struct with a similar name but not quite the same.

Fixing these limitations probably require to add a new feature to [rust-analyzer](https://github.com/rust-lang/rust-analyzer) ...