### PR TITLE
Resolve infinite recursion in command "postinstall"

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "check-types": "tsc --build",
     "clean": "rimraf dist out node_modules/.tmp .vscode-test",
     "format": "prettier --write src",
-    "postinstall": "npm --prefix node_modules/@designbyadrian/react-interactive-input/ install && npm --prefix node_modules/@designbyadrian/react-interactive-input/ run build",
+    "postinstall": "npm --ignore-scripts --prefix node_modules/@designbyadrian/react-interactive-input/ install && npm --prefix node_modules/@designbyadrian/react-interactive-input/ run build",
     "lint": "eslint src",
     "storybook": "storybook dev -p 6006",
     "vscode:prepublish": "npm run build",


### PR DESCRIPTION
I'm not sure why, but on my system (Windows 10), running `npm install` triggers recursive calls of postinstall.

This can be fixed by adding the `--ignore-scripts` argument, which prevents the `postinstall` hook from executing after installing `@designbyadrian/react-interactive-input`.
