### PR TITLE
Format entity IDs by `{number}v{number}`

### DIFF
--- a/src/extension/entities/entitiesDataProvider.ts
+++ b/src/extension/entities/entitiesDataProvider.ts
@@ -78,9 +78,9 @@ export class EntityTreeDataProvider implements vscode.TreeDataProvider<EntityNod
 
 function entityIdToString(entityId: EntityId): string {
   // Mask to get the lowest 32 bits.
-  const low = Number(BigInt(entityId) & 0xffffffffn);
+  const low = BigInt(entityId) & 0xffffffffn;
   // Shift right by 32 bits to get the high part, then mask.
-  const high = Number((BigInt(entityId) >> 32n) & 0xffffffffn);
+  const high = (BigInt(entityId) >> 32n) & 0xffffffffn;
   return `${low}v${high}`;
 }
 

--- a/src/extension/entities/entitiesDataProvider.ts
+++ b/src/extension/entities/entitiesDataProvider.ts
@@ -9,6 +9,7 @@ class EntityItem extends vscode.TreeItem {
       entity.children.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
     super(label, collapsibleState);
     this.id = String(entity.id);
+    this.tooltip = this.id;
     this.description = entity.name || findNameFromComponents(entity.componentNames);
     this.iconPath = new vscode.ThemeIcon(
       findIconFromComponents(entity.componentNames) || 'symbol-class',

--- a/src/extension/entities/entitiesDataProvider.ts
+++ b/src/extension/entities/entitiesDataProvider.ts
@@ -4,7 +4,7 @@ import type { EntityNode } from './entityTree';
 
 class EntityItem extends vscode.TreeItem {
   constructor(entity: EntityNode) {
-    const label = String(entity.id);
+    const label = entityIdToString(entity.id);
     const collapsibleState =
       entity.children.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
     super(label, collapsibleState);
@@ -73,6 +73,14 @@ export class EntityTreeDataProvider implements vscode.TreeDataProvider<EntityNod
       ? node
       : node.children.map((child) => this.findParentRecursive(child, childId)).find((found) => found !== undefined);
   }
+}
+
+function entityIdToString(entityId: EntityId): string {
+  // Mask to get the lowest 32 bits.
+  const low = Number(BigInt(entityId) & 0xffffffffn);
+  // Shift right by 32 bits to get the high part, then mask.
+  const high = Number((BigInt(entityId) >> 32n) & 0xffffffffn);
+  return `${low}v${high}`;
 }
 
 function findNameFromComponents(typePaths: TypePath[]): string | undefined {


### PR DESCRIPTION
## Problem

- #18.

## Solution

Use the same "algorithm" as Bevy: [`crates/bevy_ecs/src/identifier/masks.rs`](https://github.com/bevyengine/bevy/blob/v0.16.1/crates/bevy_ecs/src/identifier/masks.rs#L13).

| Before | After |
|--------|--------|
| <img width="261" alt="image" src="https://github.com/user-attachments/assets/330e6679-ef87-438d-a109-5639d45c2ab7" /> | <img width="261" alt="image" src="https://github.com/user-attachments/assets/5776add6-64f0-4394-b53a-b4483b81df8c" /> |

Tooltip is set as the old numeric ID.
<img width="258" alt="image" src="https://github.com/user-attachments/assets/df6e8447-6b4c-41c4-bcf0-930fb46eb759" />