### PR TITLE
Default collapsibles (components, resources) to start collapsed

### DIFF
--- a/src/schema-components/TypedValueDetails.tsx
+++ b/src/schema-components/TypedValueDetails.tsx
@@ -43,7 +43,7 @@ export function TypedValueDetails({ typedValue }: TypedValueDetailsProps) {
 
   return (
     <vscode-form-container>
-      <vscode-collapsible title={typedValue.schema.shortPath} description={typedValue.schema.typePath} open>
+      <vscode-collapsible title={typedValue.schema.shortPath} description={typedValue.schema.typePath}>
         <DynamicValue path="" value={typedValue.value} schema={typedValue.schema} onValueChange={onValueChange} />
       </vscode-collapsible>
     </vscode-form-container>


### PR DESCRIPTION
Finding the component you care about can be rather tedious as mentioned in #33. This PR starts the collapsibles as closed. 

closes #33

This is my first time contributing in this repo. I tried to follow the `CONTRIBUTING.MD` but let me know if I missed something. 